### PR TITLE
Add patch for directory traversal

### DIFF
--- a/lib/responder.js
+++ b/lib/responder.js
@@ -3,8 +3,11 @@ const { lookup } = require('mime-types')
 
 const { STATIC_EXTENSIONS } = require('../config/constants')
 
+const SAFE_FILE_PATTERN = /^\/?[a-zA-Z0-9_-]+\.[a-z]+$/;
+
 const serveStaticFile = async ({ file, extension, statusCode }, response) => {
   if (STATIC_EXTENSIONS.indexOf(extension) === -1) throw new Error('not_found')
+  if (!SAFE_FILE_PATTERN.test(file)) throw new Error('not_found')
 
   let fileHandle
 


### PR DESCRIPTION
I'm really loving this tutorial, but I noticed a security vulnerability and thought it might be good to patch it up.

I was able to confirm the issue locally in Postman (outside a web browser) hitting a url like: `http://localhost:1234/../../../Downloads/test.js`

Tested the original page still loads.